### PR TITLE
pre-commitのフォーマットのオプション修正

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ repos:
     rev: v4.3.4
     hooks:
     -   id: isort
+        args:
+          - -fas
+          - -fass
+          - --recursive
+          - --force-single-line
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v1.4.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 110


### PR DESCRIPTION
# これはなに
* precommit に適用してるisortとblackのオプションが追加されてなかったので追加した．