### PR TITLE
Fix queue_handler

### DIFF
--- a/.chalice/config.json
+++ b/.chalice/config.json
@@ -4,7 +4,7 @@
     "stages": {
         "local": {
             "environment_variables": {
-                "ORIGIN": "http://localhost:8080",
+                "ORIGIN": "*",
                 "PASSWORD_SALT": "a93bae912d8740c0bfddb4ec33417bf7",
                 "PASSWORD_ITERATION": "1000",
                 "AWS_IP_RANGES_URL": "https://ip-ranges.amazonaws.com/ip-ranges.json",
@@ -22,7 +22,7 @@
                 "AUDIT_LIST_MAX_COUNT": "300",
                 "SCANNER": "casval-stub",
                 "STAGE": "dev",
-                "S3_BUCKET_NAME": "casval-dev20181017064358523100000001",
+                "S3_BUCKET_NAME": "casval-dev20181203091304763500000001",
                 "DB_NAME": "casval_local",
                 "DB_ENDPOINT": "localhost",
                 "DB_USER": "root",
@@ -35,14 +35,14 @@
             "lambda_memory_size": 512,
             "lambda_timeout": 300,
             "subnet_ids": [
-                "subnet-0258e0090498fd744",
-                "subnet-0de2633db146b3088"
+                "subnet-0b44d5ba8d96d4b08",
+                "subnet-07dd8db75db5799be"
             ],
             "security_group_ids": [
-                "sg-0d93bd7722acebb9d"
+                "sg-00f45c1c935861d76"
             ],
             "environment_variables": {
-                "ORIGIN": "http://localhost:8080",
+                "ORIGIN": "*",
                 "PASSWORD_SALT": "a93bae912d8740c0bfddb4ec33417bf7",
                 "PASSWORD_ITERATION": "1000",
                 "AWS_IP_RANGES_URL": "https://ip-ranges.amazonaws.com/ip-ranges.json",
@@ -60,7 +60,7 @@
                 "AUDIT_LIST_MAX_COUNT": "300",
                 "SCANNER": "casval-openvas-dev",
                 "STAGE": "dev",
-                "S3_BUCKET_NAME": "casval-dev20181017064358523100000001",
+                "S3_BUCKET_NAME": "casval-dev20181203091304763500000001",
                 "DB_NAME": "casval_dev",
                 "DB_ENDPOINT": "casval-aurora-cluster.cluster-ccykysrksugc.us-east-1.rds.amazonaws.com",
                 "DB_USER": "admin",

--- a/chalicelib/core/report.py
+++ b/chalicelib/core/report.py
@@ -15,7 +15,7 @@ class Report(object):
     def load(self):
         try:
             report = self.storage.load(self.key)
-            return report
+            return report, None
         except Exception as e:
             return None, e
 

--- a/chalicelib/core/storage.py
+++ b/chalicelib/core/storage.py
@@ -13,5 +13,5 @@ class Storage(object):
 
     def store(self, key, body):
         obj = self.s3.Object(self.bucket, key)
-        obj.put(Body=body.encode("utf-8"), ContentEncoding="utf-8")
+        obj.put(Body=str(body).encode("utf-8"), ContentEncoding="utf-8")
         return True


### PR DESCRIPTION
#### chalicelib/core/report.py
https://github.com/recruit-tech/casval-rem/blame/master/chalicelib/batches/queue_handler.py#L149
この修正時にReport.load()の返り値を正しく修正していなかったため修正した。

#### chalicelib/core/storage.py
bodyがbyte型だったためstr()で文字列化する修正を加えた。

#### chalicelib/batches/queue_handler.py
https://github.com/recruit-tech/casval-openvas/pull/2
この修正に対応して大幅に修正を行った。

scanner.parse_report(report)の返り値はOpenVASResultのrecords配列を求めていたが、lambda経由で連携するため参照型では値を返せない。そのためプリミティブ型としてcasval-openvas側でrecord_parseした値を返している。
この返り値はreportの配列とvulnの配列を持った辞書型です。


