### PR TITLE
message内にip addressを情報の追加

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-skip=queue_handler_test.py
+skip=queue_handler_test.py, deploy_handler_test.py

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ validators = "*"
 peewee = "*"
 peewee-validates = {git = "https://github.com/timster/peewee-validates.git"}
 peewee-seed = "*"
+kubernetes = "*"
 
 [dev-packages]
 hacking = {git = "https://github.com/aruneko/hacking.git"}

--- a/chalicelib/apis/__init__.py
+++ b/chalicelib/apis/__init__.py
@@ -1,8 +1,8 @@
 from chalicelib.apis import audit
 from chalicelib.apis import auth
 from chalicelib.apis import scan
-from chalicelib.apis import vuln
 from chalicelib.apis import test
+from chalicelib.apis import vuln
 
 AuditAPI = audit.AuditAPI
 AuthAPI = auth.AuthAPI

--- a/chalicelib/apis/scan.py
+++ b/chalicelib/apis/scan.py
@@ -1,5 +1,6 @@
 from chalicelib.apis.base import APIBase
 from chalicelib.core import Queue
+from chalicelib.core.deploy import Deploy
 from chalicelib.core.models import Audit
 from chalicelib.core.models import Result
 from chalicelib.core.models import Scan
@@ -212,5 +213,6 @@ class ScanAPI(APIBase):
             "schedule_uuid": schedule_uuid,
             "scan_id": scan_id,
             "audit_id": audit_id,
+            "req_ip": Deploy().on_push_message(),
         }
         queue.enqueue(message)

--- a/chalicelib/core/deploy.py
+++ b/chalicelib/core/deploy.py
@@ -1,0 +1,59 @@
+from kubernetes import client
+
+import os
+import yaml
+
+path = os.path.abspath("..")
+yaml_path = path + "/deployment_rep/openvas.yaml"
+
+mock_address = "10.0.0.1"
+
+
+class Deploy(object):
+    def __init__(self, target_host=None, target_name=None):
+        self.host = target_host
+        self.name = target_name
+        self.host = self.__on_push()
+
+    def on_push_message(self):
+        return self.host
+
+    def __on_push(self):
+        # u mocking use k8s ip
+        return mock_address
+        # k8s = K8sModel()
+        # k8s.make_pod()
+        # return k8s.get_ip_address()
+
+
+class K8sModel(object):
+    def __init__(self):
+        self.pod_ip = ""
+        self.k8s_ip = ""
+
+    def make_deployment(self):
+        configuration = client.Configuration()
+
+        configuration.api_key["authorization"] = "<bearer_token>"
+        configuration.api_key_prefix["authorization"] = "Bearer"
+
+        configuration.host = "https://" + self.k8s_ip
+
+        configuration.ssl_ca_cert = "<path_to_cluster_ca_certificate>"
+
+        # make api instance
+        client.CoreV1Api(client.ApiClient(configuration))
+
+        deploy_api = client.ExtensionsV1beta1Api(client.ApiClient(configuration))
+
+        # use make yaml deployment
+        with open(yaml_path) as f:
+            deploy_body = yaml.load(f)
+            try:
+                req = deploy_api.create_namespaced_deployment(body=deploy_body, namespace="casval-rem")
+                self.pod_ip = req.status.pod_ip
+            except Exception as e:
+                raise e
+
+    def get_ip_address(self):
+        return self.pod_ip

--- a/chalicelib/core/stub/queues.py
+++ b/chalicelib/core/stub/queues.py
@@ -38,8 +38,8 @@ class SQSMock(object):
         self.queue.delete_messages(Entries=[entry])
 
     def message_count(self):
-        if int(os.environ["GEN_CREATE_QUEUE"]) == -1:
-            client = boto3.client("sqs", region_name="us-east-1")
+        if int(os.getenv("GEN_CREATE_QUEUE", 0)) == -1:
+            client = boto3.client("sqs")
             response = client.get_queue_attributes(
                 QueueUrl=self.queue.url,
                 AttributeNames=["ApproximateNumberOfMessages", "ApproximateNumberOfMessagesNotVisible"],
@@ -50,7 +50,7 @@ class SQSMock(object):
             total_message_num = int(message_num) + int(message_num_not_visible)
             return total_message_num
         else:
-            return int(os.environ["GEN_CREATE_QUEUE"])
+            return int(os.getenv("GEN_CREATE_QUEUE", 0))
 
     @staticmethod
     def dispose():

--- a/tests/deploy_handler_test.py
+++ b/tests/deploy_handler_test.py
@@ -1,0 +1,107 @@
+# fmt: off
+import os
+from tests.load_env import loadenv  # noqa: F402
+loadenv("local")   # noqa: F402
+os.environ["DB_TYPE"] = "sqlite"   # noqa: F402
+os.environ["UNIT_TEST"] = "True"   # noqa: F402
+# fmt: on
+
+from app import app
+from chalicelib.apis import ScanAPI
+from chalicelib.batches.queue_handler import QueueHandler
+from chalicelib.core import Queue
+from chalicelib.core.models import db
+from chalicelib.core.stub.queues import SQSMock
+from moto import mock_sqs
+from peewee_seed import PeeweeSeed
+
+import chalicelib.core.deploy as dp
+import freezegun
+import json
+
+
+path_carrent = os.path.abspath(".")
+
+
+def session_factory():
+    entry = {
+        "Id": "5fea7756-0ea4-451a-a703-a558b933e274",
+        "ReceiptHandle": "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw"
+        "Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE"
+        "auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=",
+    }
+    body = {
+        "target": "127.0.0.1",
+        "start_at": "2018-12-27 09:00:00",
+        "end_at": "2018-12-27 14:00:00",
+        "schedule_uuid": "e3a398ca0bb74673b582c4c81d6c2f03",
+        "scan_id": 4,
+        "audit_id": 4,
+        "session": {"host": "127.0.0.1", "target_id": "<scan_id>", "port": 9390, "scan_id": "<target_id>"},
+    }
+    return entry, body
+
+
+def db_seed(remove=False):
+    path = path_carrent + "/chalicelib/apis/fixtures/"
+    fixtures_list = ["audits.json", "scans.json", "contacts.json", "results.json", "vulns.json"]
+    seeds = PeeweeSeed(db, path, fixtures_list)
+    if remove:
+        seeds.drop_table_all(fixtures_list, foreign_key_checks=True)
+    else:
+        seeds.create_table_all()
+        seeds.db_data_input()
+
+
+class TestQueueHandler(object):
+    def setup_class(self):
+        db_seed()
+        os.environ["GEN_CREATE_QUEUE"] = str(0)
+
+    def teardown_method(self):
+        SQSMock.dispose()
+        os.environ["GEN_CREATE_QUEUE"] = str(0)
+
+    # the normal handler
+    # ex :
+    # freeze_time('2018-12-26 08:00:00+00:00') は実際にはこれがutcになるので
+    # jstでは`2018-12-26 17:00:00+09:00`となる
+
+    # check queue message in pod ip address
+    @mock_sqs
+    @freezegun.freeze_time("2018-12-27 10:00:00")
+    def test_deploy_scanapi(self):
+        pending_queue = Queue(Queue.SCAN_PENDING)
+        running_queue = Queue(Queue.SCAN_RUNNING)
+
+        scanapi = ScanAPI(app, "3cd708cefd58401f9d43ff953f063467")
+
+        dp.mock_address = "10.0.0.10"
+        entry, body = session_factory()
+
+        scanapi._ScanAPI__request_scan(
+            target="127.0.0.1",
+            start_at=body["start_at"],
+            end_at=body["end_at"],
+            schedule_uuid=scanapi._ScanAPI__get_schedule_uuid(),
+            scan_id="21d6cd7b33e84fbf9a2898f4ea7f90ca",
+            audit_id="3cd708cefd58401f9d43ff953f063467",
+        )
+        pending_messages = pending_queue.peek()
+        body = {}
+
+        for message in pending_messages:
+            entry = {"Id": message.message_id, "ReceiptHandle": message.receipt_handle}
+            body = json.loads(message.body)
+
+        assert body["req_ip"] == "10.0.0.10"
+
+        handler = QueueHandler(app)
+        assert handler._QueueHandler__launch_scan(pending_queue, entry, body)
+
+        running_messages = running_queue.peek()
+
+        for message in running_messages:
+            body = json.loads(message.body)
+
+        assert body["req_ip"] == "10.0.0.10"

--- a/tests/queue_handler_test.py
+++ b/tests/queue_handler_test.py
@@ -43,16 +43,22 @@ def session_factory():
     return entry, body
 
 
-def db_seed():
+def db_seed(remove=False):
     path = path_carrent + "/chalicelib/apis/fixtures/"
-    seeds = PeeweeSeed(db, path, ["audits.json", "scans.json", "contacts.json", "results.json", "vulns.json"])
-    seeds.create_table_all()
-    seeds.db_data_input()
+    fixtures_list = ["audits.json", "scans.json", "contacts.json", "results.json", "vulns.json"]
+    seeds = PeeweeSeed(db, path, fixtures_list)
+    if remove:
+        # bugfix to Library
+        seeds.drop_table_all(fixtures_list, foreign_key_checks=True)
+    else:
+        seeds.create_table_all()
+        seeds.db_data_input()
 
 
 class TestQueueHandler(object):
     def setup_class(self):
-        db_seed()
+        # db_seed()
+        os.environ["GEN_CREATE_QUEUE"] = str(0)
 
     def teardown_method(self):
         SQSMock.dispose()

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length=110
-ignore = H102, H306, W503
+ignore = H102, H306, W503, F632


### PR DESCRIPTION
# これは何
k8sのdeploymentで使うためにqueue messageの中にpod ipaddressを入れるということをしました
# やったこと
- ipaddressを突っ込むハンドラーを作った
- テストをした(pendingqueueに入れてそのあとrunningqueueへの受け渡しまで確認した)
- モックでk8sのhandlerを用意した

# 次やること
- peewee seedsの方がmysqlで使うためベースに書いてたのでsqlliteで動かすとき向けにフラグを追加する(そのせいでsqliteではDBの全件削除が直接SQLを書かないといけない状況。だがdevには急ぎで問題がないので優先度が高くない）
- k8sのデプロイメントを動かせるやつを別のPRで出す
- unitテスト周りのものを整理する(e.g. bodyのモックとかはimportする形に整理する。)