### PR TITLE
k8sへのdeployhandlerの作成

### DIFF
--- a/chalicelib/core/deploy.py
+++ b/chalicelib/core/deploy.py
@@ -23,14 +23,14 @@ class Deploy(object):
         return k8s.get_service_ip_address()
 
     @staticmethod
-    def delete_service(name, service_ip):
-        k8s = KubeDeploy(service_ip)
+    def delete_service(name):
+        k8s = KubeDeploy()
         # ip_addrを取って渡す
         return k8s.delete_service(name)
 
     @staticmethod
-    def delete_deployment(name, service_ip):
-        k8s = KubeDeploy(service_ip)
+    def delete_deployment(name):
+        k8s = KubeDeploy()
         return k8s.delete_deployment(name)
 
 


### PR DESCRIPTION
# これはなに
GKEに対してdeploymentとserviceをRequest送って構築させる

# これはなぜ
現在の問題点としてContainerの1スケーリングするサイズをうまく取り扱うということができないということがある。加えてpodを増やすのはできるがLBする際にどのエンドポイントに何が入っているのかがわからないという問題点が存在する。
そこで1Request：1Container(正しくはpod+service)の組にして検査をするようにすることでスケーリングするようにしたい

# やったこと
- [x] k8sのクレデンシャルの保存やデータのやり取り方法の検討
- [x] service作成のRequest
- [x] deployment作成のRequest
 - [ ] unit test：message queue3つの部分でのテスト（具体的には終端部分がまだ行われていない）

# image
![Casval-deploy 001](https://user-images.githubusercontent.com/10973623/54874107-e38efa00-4e27-11e9-939b-b9c9f8e06e5c.png)
今回はここの中のk8s deploy  handlerを作成している

# 次やること
- ドライバーとなってるCasvalOpenvasにハンドラを設置する。