### PR TITLE
Add restart handling

### DIFF
--- a/core/deployers.py
+++ b/core/deployers.py
@@ -175,7 +175,7 @@ class KubernetesDeployer(Deployer):
             period_seconds=30,
         )
         liveness_probe = k8s.V1Probe(
-            tcp_socket=k8s.V1TCPSocketAction(port=9390),
+            tcp_socket=k8s.V1TCPSocketAction(port=container_port.container_port),
             initial_delay_seconds=180,
             period_seconds=30,
             failure_threshold=3,

--- a/core/scanners.py
+++ b/core/scanners.py
@@ -84,7 +84,7 @@ class OpenVASScanner:
         return self.session
 
     def check_status(self):
-        if not Deployer(self.session["ov_deployment_id"]).is_restarted():
+        if Deployer(self.session["ov_deployment_id"]).is_restarted():
             return ScanStatus.FAILED
 
         status = self.conn.get_scan_status(self.session["ov_scan_id"])

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -270,7 +270,7 @@ class RunningTask(BaseTask):
             app.logger.info("Scan stopped successfully, task={task}".format(task=task))
             self._update(task, next_progress=TaskProgress.STOPPED.name)
         elif status == ScanStatus.FAILED:
-            app.logger.exception("Scan failed, task={task}".format(task=task))
+            app.logger.exception("Exception, task={task}".format(task=task))
             task["error_reason"] = "Scan was terminated due to scanner error."
             self._update(task, next_progress=TaskProgress.FAILED.name)
         else:


### PR DESCRIPTION
# Task 
- [x] Add handling when pod is restarted
- [x] Add annotation `cluster-autoscaler.kubernetes.io/safe-to-evict `
- [x] Add readinessProbe
- [x] Add livenessProbe
- [x] Fix exception message.  https://github.com/recruit-tech/casval-rem/compare/add_restart_handling?expand=1#diff-e26197584f061c5b25848f4edaf661e7R273

# NOTE

### Add handling when pod is restarted.
Check restart_count of pod at check_status.

### Add annotation
Prevent pod from being rescheduled by node scale in. 
https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler

### Add readinessProbe
Check if the openvas container entrypoint is running.
https://github.com/mikesplain/openvas-docker/blob/master/9/start#L119

### Add livenessProbe
Restart pod when the container is not listening to 9390.
